### PR TITLE
set correct capp return variable for capp_checkout

### DIFF
--- a/capp.cmake
+++ b/capp.cmake
@@ -307,7 +307,7 @@ function(capp_checkout)
   message("debug: submodule update of ${package} completed")
   message("debug: checkout of ${package} succeeded")
   #We did it. We "checked out a commit".
-  set(${capp_clone_RESULT_VARIABLE} 0 PARENT_SCOPE)
+  set(${capp_checkout_RESULT_VARIABLE} 0 PARENT_SCOPE)
 endfunction()
 
 function(capp_clone)


### PR DESCRIPTION
An unset result variable was causing fresh builds for me to fail. I believe this commit fixes that behavior by setting the appropriate return variable.